### PR TITLE
Include item count in search endpoint

### DIFF
--- a/data/json/productsdup.json
+++ b/data/json/productsdup.json
@@ -1,0 +1,252 @@
+[
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0788" },
+		"title": "Aceite esencial de Clavo",
+		"units": "12ML",
+		"price": 7.99,
+		"priceperunit": "Sale a: 665,83 €/L",
+		"discount": 0,
+		"description": "El aceite esencial de clavo es conocido por sus increíbles propiedades antimicrobianas, antimicóticas, antisépticas, antivirales, afrodisíacas y estimulantes. Perfecto para utilizar en tus mezclas de Cosmética Natural, añadiendo unas cuantas gotas en tu crema corporal o aceite vegetal, conseguirás nutrir y lucir una piel radiante y 100% cuidad.",
+		"imageurl": "1.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0789" },
+		"title": "6 Discos Desmaquillantes de Fibra Natural",
+		"units": "6UDS.",
+		"price": 10.5,
+		"priceperunit": "Sale a: 1,75 €/ud.",
+		"discount": 0,
+		"description": "Eliminan el maquillaje y limpian el rostro con suavidad. Elaborados en algodón y carbón de bambú. De doble cara y función: Limpieza diaria: elaborada en algodón ultrasuave es adecuada para productos líquidos. Exfoliante: combinación de algodón y carbón de bambú, de propiedades purificantes y desintoxicantes. Indicada para texturas cremosas y densas. Incluye 6 discos y una práctica bolsita de algodón para lavarlos ( máx. 30 grados) y guardarlos. No secar en secadora. Reúnen ahorro en otros productos de un solo uso (toallitas, discos de algodón) y máximo respeto por el medio ambiente.",
+		"imageurl": "2.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab078a" },
+		"title": "Parches de Oro de 24 kt Rejuvenecedores para Contorno de Ojos",
+		"units": "60UDS.",
+		"price": 15.5,
+		"priceperunit": "Sale a: 0,26 €/ud.",
+		"discount": 0,
+		"description": "Parches de oro de 24 kt rejuvenecedores para contorno de ojos de Natura Siberica. Parches para ojos con efecto rejuvenecedor enriquecidos con oro de 24kt. Su acción descongestiona la piel, la suaviza y mejora su luminosidad. Estos parches con oro de 24kt son la opción perfecta para rejuvenecer la mirada en pocos minutos. Basados en activo postbiótico único y extractos fermentados de mora de los pantanos norteña y frambuesa silvestre, contienen dos activos únicos para combatir los signos de envejecimiento: el complejo de polipéptidos SYN-COLL® y oro de 24kt. Gracias a ellos, estimulan la síntesis de colágeno en las células de la piel y ayudan a suavizar las arrugas, mejorando la ",
+		"imageurl": "3.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab078b" },
+		"title": "Aceite anticelulítico de abedul",
+		"units": "100ML",
+		"price": 22.9,
+		"priceperunit": "Sale a: 229,00 €/L",
+		"discount": 0,
+		"description": "El extracto de hojas de abedul contiene flavonoides y tanines, los cuales sirven para mantener y conservar el metabolismo y circulación de los líquidos en el cuerpo. Su función es dar firmeza, elasticidad y suavidad a la piel, previniendo y mejorando el estado de la misma. Por esta razón, previene y mejora la celulitis. No contiene ni sustancias químicas, ni colorantes, ni conservantes. Es apto para veganos y no está testado en animales.",
+		"imageurl": "4.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab078c" },
+		"title": "Aceite antiinflamatorio S.O.S Rescate",
+		"units": "30ML",
+		"price": 12.45,
+		"priceperunit": "Sale a: 415,00 €/L",
+		"discount": 0,
+		"description": "Pequeñas heridas, quemaduras, golpes, cicatrices… ¿Cuántos productos diferentes estás usando para paliar estos accidentes? Pues a partir de ahora con uno sólo podrás calmar y regenerar tu piel y la de toda tu familia con S. O. S. Rescate, una extraordinaria mezcla de aceites vegetales y esenciales procedentes de agricultura ecológica.",
+		"imageurl": "5.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab078d" },
+		"title": "Aceite Bucal de Coco Orgánico Premium",
+		"units": "180ML",
+		"price": 9.6,
+		"priceperunit": "Sale a: 53,33 €/L",
+		"discount": 0,
+		"description": "Oil Pulling de Dr. Goerg. El aceite bucal de coco orgánico premium de Dr. Goerg es fácil de usar y, gracias a sus ingredientes 100 % naturales enriquecidos con aceites esenciales de menta y eucalipto, garantiza una sensación en la boca limpia, agradable y fresca. Nuestro aceite bucal orgánico premium también es 100% vegano y está certificado como cosmético orgánico por Cosmos Organic . Si se usa regularmente antes de cepillarse los dientes, la extracción de aceite puede garantizar un aliento fresco y encías bien cuidadas a largo plazo. Al igual que con todos nuestros productos orgánicos premium, solo utilizamos las mejores materias primas de cultivos exclusivamente sostenibles para nuestro aceite de boca de coco orgánico premium.",
+		"imageurl": "6.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab078e" },
+		"title": "Aceite corporal blanco siberiano anticelulítico de Natura Siberica",
+		"units": "200ML",
+		"price": 6.95,
+		"priceperunit": "Sale a: 34,75 €/L",
+		"discount": 0,
+		"description": "Este producto te trae lo mejor para el cuidado de tu cuerpo gracias a las propiedades de la cera blanca de abeja, los aceites naturales y la schizandra. Regálate lo mejor para tu piel y disfruta de esta combinación que hidratará de forma eficaz las zonas de tu cuerpo que más lo necesite.",
+		"imageurl": "7.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab078f" },
+		"title": "Aceite corporal de almendras dulces",
+		"units": "500ML",
+		"price": 10.45,
+		"priceperunit": "Sale a: 20,90 €/L",
+		"discount": 0,
+		"description": "El Aceite de Almendras dulces es básico para una hidratación y nutrición de la piel. Puedes utilizarlo en todas las partes de tu cuerpo preferiblemente después de la ducha con la piel húmeda, para ayudar a su absorción llegando a las capas profundas de la piel. Un aceite neutro apto para todo tipo de pieles y edades, utilizándose para toda la familia desde las edades más tempranas. Es ideal como base para formularlo con otros aceites, aceites esenciales y lociones.",
+		"imageurl": "8.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0790" },
+		"title": "Aceite corporal Body Sculptor",
+		"units": "",
+		"price": 73.7,
+		"priceperunit": "Sale a: 491,33 €/L",
+		"discount": 0,
+		"description": "Aceite corporal que moldea el cuerpo y esculpe la silueta de forma natural y eficaz. Previene el exceso de peso y la retención de líquidos gracias a su acción drenante, activa la microcirculación a la vez que tonifica la piel. Esculpe tu cuerpo realizando tratamientos de forma diaria. Está formulado con aceites vegetales naturales adecuado para pieles sensibles.",
+		"imageurl": "9.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0791" },
+		"title": "Aceite corporal de almendras dulces con dosificador 1L",
+		"units": "1L",
+		"price": 14.99,
+		"priceperunit": "Sale a: 14,99 €/L",
+		"discount": 0,
+		"description": "El Aceite de Almendras dulces es básico para una hidratación y nutrición de la piel. Puedes utilizarlo en todas las partes de tu cuerpo preferiblemente después de la ducha con la piel húmeda, para ayudar a su absorción llegando a las capas profundas de la piel. Un aceite neutro apto para todo tipo de pieles y edades, utilizándose para toda la familia desde las edades más tempranas. Es ideal como base para formularlo con otros aceites, aceites esenciales y lociones.",
+		"imageurl": "10.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0792" },
+		"title": "Aceite corporal de almendras dulces con dosificador 500ml",
+		"units": "500ML",
+		"price": 11.55,
+		"priceperunit": "Sale a: 23,10 €/L",
+		"discount": 0,
+		"description": "El Aceite de Almendras dulces es básico para una hidratación y nutrición de la piel. Puedes utilizarlo en todas las partes de tu cuerpo preferiblemente después de la ducha con la piel húmeda, para ayudar a su absorción llegando a las capas profundas de la piel. Un aceite neutro apto para todo tipo de pieles y edades, utilizándose para toda la familia desde las edades más tempranas. Es ideal como base para formularlo con otros aceites, aceites esenciales y lociones.",
+		"imageurl": "11.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0793" },
+		"title": "Aceite Corporal de Granada",
+		"units": "100ML",
+		"price": 22.9,
+		"priceperunit": "Sale a: 229,00 €/L",
+		"discount": 0,
+		"description": "El aceite corporal de granada es de acción antioxidante intensiva que sirve para la regeneración celula, reafirmando y mejorando la elasticidad. Está indicado para pieles secas, maduras y estresadas, pues ayuda a prevenir el envejecimiento prematuro de la piel. Con ingredientes 100% naturales y ecológicos, que otorgan un aroma sensual y dulce. Testado dermatológicamente, no testado en animales. Apto para veganos.",
+		"imageurl": "12.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0794" },
+		"title": "Aceite Corporal de Rosa Mosqueta",
+		"units": "100ML",
+		"price": 22.9,
+		"priceperunit": "Sale a: 229,00 €/L",
+		"discount": 0,
+		"description": "La principal acción de la Rosa Mosqueta es la regeneración de la piel y elasticidad, aportando tonicidad a la piel. Combate los primeros signos de envejecimiento de la piel. Este producto combina la acción alisante de la rosa mosqueta con las propiedades hidratantes del aceite de jojoba. Da como resultado un aceite muy nutritivo, de una textura ligera y muy absorvente. Testado dermatológicamente en todo tipo de pieles, pero no en animales. Apto para veganos. De uso diario.",
+		"imageurl": "13.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0795" },
+		"title": "Aceite corporal Embellecedor del Busto",
+		"units": "",
+		"price": 81.7,
+		"priceperunit": "Sale a: 817,00 €/L",
+		"discount": 0,
+		"description": "Aceite corporal empleado para moldear y realzar el busto dándole una apariencia de mayor volumen. Hidrata y nutre ayudando a prevenir las estrías de esta zona tan sensible. Utilízalo directamente con ligeros masajes circulares hasta su total absorción. Puedes utilizarlo de forma diaria, para mejores resultados te aconsejamos de dos a tres aplicaciones al día.",
+		"imageurl": "14.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0796" },
+		"title": "Aceite corporal Reafirmante de Tejidos",
+		"units": "",
+		"price": 60,
+		"priceperunit": "Sale a: 400,00 €/L",
+		"discount": 0,
+		"description": "Aceite corporal indispensable para prevenir la pérdida de firmeza de los tejidos y reafirmar las zonas que presentan flacidez. Puedes hidratar tu cuerpo de forma diaria con este aceite y beneficiarte de sus propiedades reafirmantes. Con ingredientes totalmente naturales consigue una hidratación en las capas profundas de la piel.",
+		"imageurl": "15.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0797" },
+		"title": "Aceite corporal Reafirmante del Busto",
+		"units": "",
+		"price": 81.7,
+		"priceperunit": "Sale a: 817,00 €/L",
+		"discount": 0,
+		"description": "Aceite corporal específico de tratamiento que reafirma eficazmente el seno caído a la vez que hidrata y suaviza la piel devolviéndole su belleza. El tratamiento natural con este aceite realza el busto para que se muestre más bello. Este aceite está libre de hormonas y otros componentes químicos, se basa en ingredientes naturales con propiedades hidratantes y estimuladoras.",
+		"imageurl": "16.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0798" },
+		"title": "Parches Iluminadores para el Contorno de Ojos",
+		"units": "60UDS.",
+		"price": 15.5,
+		"priceperunit": "Sale a: 0,26 €/ud.",
+		"discount": 0,
+		"description": "Parches iluminadores para el contorno de ojos de Natura Siberica. 60 Parches para ojos con efecto iluminador que hidratan la piel del contorno, le devuelven la vitalidad y mejoran su protección para mantenerla joven. Estos parches iluminadores son una solución rápida y cómoda para darle a tus ojos ese toque de luz y vitalidad que el estrés y la vida urbana les van quitando. Con su base de biome con activo postbiótico único y extractos fermentados de mora de los pantanos norteña y frambuesa silvestre ayudan al microbioma de la piel a aumentar su resistencia y mejorar su luminosidad. La vitamina C presente en su fórmula mejora el tono y la textura del contorno para ayudar a recuperar su brillo natural, y la niacinamida contribuye a fortalecer la barrera de hidratación de la epidermis, dando lugar a un resultado suave, esplendoroso y rejuvenecido.",
+		"imageurl": "17.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab0799" },
+		"title": "Aceite daúrico corporal de Natura Siberica",
+		"units": "",
+		"price": 18.95,
+		"priceperunit": "Sale a: 51,22 €/L",
+		"discount": 0,
+		"description": "Relaja tu cuerpo con este fantástico producto con el que podrás disfrutar de momentos únicos. Aceite daúrico corporal es perfecto para pieles secas. Una explosión de sensaciones gracias a su composición que revitalizará tu piel.",
+		"imageurl": "18.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab079a" },
+		"title": "Aceite corporal Reina de Egipto",
+		"units": "",
+		"price": 57.3,
+		"priceperunit": "Sale a: 382,00 €/L",
+		"discount": 0,
+		"description": "Aceite corporal de exótica fragancia que nutre en profundidad, combate el envejecimiento cutáneo, regenera y alisa, a la vez que aporta autoestima y confianza. Este aceite es muy usado y recomendado entre nuestros clientes gracias a su versatilidad y eficacia.",
+		"imageurl": "19.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab079b" },
+		"title": "Aceite de Aguacate corporal",
+		"units": "125ML",
+		"price": 15,
+		"priceperunit": "Sale a: 120,00 €/L",
+		"discount": 0,
+		"description": "El aceite de aguacate actúa un bálsamo perfecto para la piel. Destaca por su efecto nutritivo, protector y regenerante. Indicado para pieles secas, agrietadas y envejecidas. Tiene una excelente penetración y además ayuda a filtrar de forma natural la radiación solar.",
+		"imageurl": "20.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab079c" },
+		"title": "Aceite de almendras corporal Bio",
+		"units": "125ML",
+		"price": 14.95,
+		"priceperunit": "Sale a: 119,60 €/L",
+		"discount": 0,
+		"description": "Hidrata y nutre tu piel con este aceite de almendras ecológico de primera prensada en frío. Te recomendamos su uso después de la ducha con la piel húmeda, mejora su absorción. Puedes utilizarlo de base para formularlo con otro aceites, aceites esenciales y lociones.",
+		"imageurl": "21.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab079d" },
+		"title": "Aceite de Argán Bio",
+		"units": "30ML",
+		"price": 12.99,
+		"priceperunit": "Sale a: 433,00 €/L",
+		"discount": 0,
+		"description": "Este aceite vegetal rico en vitaminas y antioxidantes te hará lucir una piel radiante. El aceite de argán te aportará la luminosidad y elasticidad que necesitas para presumir de belleza natural. Ideal para todo tipo de pieles y capaz de nutrir las capas profundas de la piel.",
+		"imageurl": "22.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab079e" },
+		"title": "Aceite de Argán Bio",
+		"units": "100ML",
+		"price": 25.95,
+		"priceperunit": "Sale a: 259,50 €/L",
+		"discount": 0,
+		"description": "Este aceite vegetal rico en vitaminas y antioxidantes te hará lucir una piel radiante. El aceite de argán te aportará la luminosidad y elasticidad que necesitas para presumir de belleza natural. Ideal para todo tipo de pieles y capaz de nutrir las capas profundas de la piel.",
+		"imageurl": "23.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab079f" },
+		"title": "Aceite de CBD 5%",
+		"units": "15ML",
+		"price": 20.95,
+		"priceperunit": "Sale a: 20,95 €/ud.",
+		"discount": 0,
+		"description": "Aceite de semillas de cáñamo con CBD al 5%. Adecuado para el uso diario en personas con dolor crónico o de intensidad alta. El aceite de cáñamo con CBD de Terra Verda es orgánico, vegano y libre de crueldad animal. Su exclusivo método de extracción permite mantener todas las propiedades de la semilla de cáñamo sin trazos de tóxicos ni alcoholes. Puedes usarlo diariamente para aliviar las dolencias articulares o musculares por el dolor crónico, días estresantes o la actividad deportiva.",
+		"imageurl": "24.jpg"
+	},
+	{
+		"_id": { "$oid": "6364ae93b758fd69b7ab07a0" },
+		"title": "Parches Supertonificantes para Contorno de Ojos",
+		"units": "60UDS.",
+		"price": 15.5,
+		"priceperunit": "",
+		"discount": 0,
+		"description": "Parches supertonificantes para contorno de ojos de Natura siberica. Parches para ojos con efecto tonificante que reducen visiblemente los signos de fatiga en la mirada y le aportan luz y vitalidad al instante. Estos parches supertonificantes son la solución definitiva para decir adiós a los signos de fatiga y la hinchazón en el contorno de los ojos. Basados en activo postbiótico único y extractos fermentados de mora de los pantanos norteña y frambuesa silvestre, crean sobre la mirada un efecto iluminador y energizante al instante. La cafeína presente en su fórmula ayuda a tensar las líneas finas y reducir la piel hinchada, mientras que la vitamina E genera un efecto regenerador que deja un aspecto descansado y revitalizado.",
+		"imageurl": "25.jpg"
+	}
+]

--- a/src/controller/store.go
+++ b/src/controller/store.go
@@ -17,6 +17,12 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+
+type FilterResponse struct {
+	TotalCount int64        `json:"totalcount" bson:"totalcount"`   
+	Products   []db.Product `json:"products"   bson:"products"`
+}
+
 func StoreFilterItems (c *gin.Context) {
 
 	// get url parameters
@@ -103,9 +109,21 @@ func StoreFilterItems (c *gin.Context) {
 		}
 	}
 
+	// get total count
+
+	//opts = options.Count().SetMaxTime(60 * time.Second)
+	count, err := coll.CountDocuments(context.TODO(), filter, options.Count())
+	if err != nil {
+		fmt.Println(err)
+		c.AbortWithStatusJSON(http.StatusInternalServerError,
+		gin.H{"message": "Internal server error"})
+		return
+	}
+	fmt.Printf("name Bob appears in %v documents", count)
+
 	fmt.Printf(
 	"\nFound %d products\nSearchterm \"%s\" PageId %d Minprice %d Maxprice %d\n",
 	len(products), searchTerm, pageId, minprice, maxprice)
 
-	c.IndentedJSON(http.StatusOK, products)
+	c.IndentedJSON(http.StatusOK, FilterResponse{ count, products })
 }

--- a/util/import-mongo.sh
+++ b/util/import-mongo.sh
@@ -10,6 +10,16 @@ mongoimport \
 	--uri "mongodb://$MONGO_USER:$MONGO_PASS@$MONGO_HOST:27017" \
 	--authenticationDatabase 'admin'
 
+# import duplicates
+
+mongoimport \
+	--db 'buenavida' \
+	--collection 'products' \
+	--file '/data/json/productsdup.json' \
+	--jsonArray \
+	--uri "mongodb://$MONGO_USER:$MONGO_PASS@$MONGO_HOST:27017" \
+	--authenticationDatabase 'admin'
+
 # import users.json
 
 mongoimport \


### PR DESCRIPTION
- Incluye el conteo total de productos en la busqueda.
- Al importar los productos a MongoDB durante el setup, se importa un duplicado para tener un total de 50 productos.

La estructura que devuelve ahora es:

```
{
	"totalcount": number,
	"products": [
		...
	]
}
```